### PR TITLE
Added InputStream constructor (#24) and fixed ImagePath (#16)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,24 @@
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+archivesBaseName = 'templ4docx'
+version = System.getenv("BUILD_NUMBER") ?: "3.0.0-Beta"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile 'pl.jsolve:sweetener:+'
+    compile 'org.apache.poi:poi:+'
+    compile 'org.apache.poi:poi-ooxml:+'
+    compile 'org.apache.commons:commons-lang3:+'
+
+    testCompile 'org.easytesting:fest-assert:+'
+    testCompile 'junit:junit:+'
+}
+
+task copyToLibs(type: Copy) {
+    into "$buildDir/libs"
+    from configurations.compile, configurations.testCompile
+}

--- a/src/main/java/pl/jsolve/templ4docx/strategy/ImageInsertStrategy.java
+++ b/src/main/java/pl/jsolve/templ4docx/strategy/ImageInsertStrategy.java
@@ -1,6 +1,5 @@
 package pl.jsolve.templ4docx.strategy;
 
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
@@ -39,9 +38,10 @@ public class ImageInsertStrategy implements InsertStrategy {
 
     private void insertPicture(XWPFRun r, ImageVariable imageVariable) {
         try {
-            r.addPicture(new FileInputStream(imageVariable.getImagePath()),
+            r.addPicture(imageVariable.getImageStream(),
                     imageVariable.getImageType().getImageType(), imageVariable.getKey(),
                     Units.toEMU(imageVariable.getWidth()), Units.toEMU(imageVariable.getHeight()));
+            imageVariable.getImageStream().reset();
         } catch (InvalidFormatException e) {
             e.printStackTrace();
         } catch (FileNotFoundException e) {

--- a/src/main/java/pl/jsolve/templ4docx/variable/ImageVariable.java
+++ b/src/main/java/pl/jsolve/templ4docx/variable/ImageVariable.java
@@ -1,10 +1,15 @@
 package pl.jsolve.templ4docx.variable;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 
 public class ImageVariable implements Variable {
 
     private String key;
+    private InputStream imageStream;
     private String imagePath;
     private File imageFile;
     private int width;
@@ -12,32 +17,34 @@ public class ImageVariable implements Variable {
     private ImageType imageType;
 
     public ImageVariable(String key, String imagePath, int width, int height) {
-        this.key = key;
-        this.imagePath = imagePath;
-        this.width = width;
-        this.height = height;
-        this.imageType = ImageType.findImageTypeForPath(imagePath);
+    	this(key, new File(imagePath), ImageType.findImageTypeForPath(imagePath), width, height);
     }
 
     public ImageVariable(String key, File imageFile, int width, int height) {
-        this.key = key;
-        this.imageFile = imageFile;
-        this.width = width;
-        this.height = height;
-        this.imageType = ImageType.findImageTypeForPath(imagePath);
+    	this(key, imageFile, ImageType.findImageTypeForPath(imageFile.getAbsolutePath()), width, height);
     }
 
     public ImageVariable(String key, String imagePath, ImageType imageType, int width, int height) {
-        this.key = key;
-        this.imagePath = imagePath;
-        this.width = width;
-        this.height = height;
-        this.imageType = imageType;
+    	this(key, new File(imagePath), imageType, width, height);
     }
 
     public ImageVariable(String key, File imageFile, ImageType imageType, int width, int height) {
+    	try {
+            this.key = key;
+            this.imageFile = imageFile;
+            this.imagePath = imageFile.getAbsolutePath();
+            this.imageStream = new ByteArrayInputStream(Files.readAllBytes(imageFile.toPath()));
+            this.width = width;
+            this.height = height;
+            this.imageType = imageType;
+    	} catch(IOException e) {
+    		e.printStackTrace();
+    	}
+    }
+
+    public ImageVariable(String key, InputStream imageStream, ImageType imageType, int width, int height) {
         this.key = key;
-        this.imageFile = imageFile;
+        this.imageStream = imageStream;
         this.width = width;
         this.height = height;
         this.imageType = imageType;
@@ -53,6 +60,10 @@ public class ImageVariable implements Variable {
 
     public File getImageFile() {
         return imageFile;
+    }
+
+    public InputStream getImageStream() {
+    	return imageStream;
     }
 
     public int getWidth() {


### PR DESCRIPTION
Added a constructor for InputStream to the ImageVariable class.  The current functionality and API compatibility is preserved; however, there is one difference and caveat: an image file is now cached in memory using a ByteArrayInputStream, this allows the ImageInsertStrategy class to reset the stream after each successive image insertion allowing for the same image file to be inserted multiple times within a document.  However, if an input stream that does not support the reset method (e.g. FileInputStream) is used then an exception will be thrown and caught by the insertPicture method.

The rationale for adding an input stream constructor was to avoid unnecessary disk IO when dynamically generating numerous images or pulling multiple images from a remote service per document.