### PR TITLE
JDK6 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.metadata
+.classpath
+.settings
+.project
+**/target/

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
 			<artifactId>fest-assert</artifactId>
 			<version>1.4</version>
 		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.5</version>
+		</dependency>
 
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>pl.jsolve</groupId>
 	<artifactId>templ4docx</artifactId>
-	<version>2.0.1</version>
+	<version>2.0.3-SNAPSHOT</version>
 	<name>templ4docx</name>
 	<description>TEMPL4DOCX - Utility library for filling templates in docx files</description>
 	<url>https://github.com/jsolve/templ4docx</url>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<poi.version>3.12</poi.version>
-		<sweetener.version>1.0.0</sweetener.version>
 		<java.version>1.6</java.version>
 		<maven-compiler-plugin.version>3.0</maven-compiler-plugin.version>
 		<maven-jar-plugin.version>2.4</maven-jar-plugin.version>
@@ -62,12 +61,6 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>3.4</version>
-		</dependency>
-
-		<dependency>
-			<groupId>pl.jsolve</groupId>
-			<artifactId>sweetener</artifactId>
-			<version>${sweetener.version}</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,86 @@
 
 	</dependencies>
 
+	<profiles>
+		<profile>
+			<id>release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<version>${maven-compiler-plugin.version}</version>
+						<configuration>
+							<source>${java.version}</source>
+							<target>${java.version}</target>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-jar-plugin</artifactId>
+						<version>${maven-jar-plugin.version}</version>
+						<executions>
+							<execution>
+								<goals>
+									<goal>test-jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
+						<version>1.6.3</version>
+						<extensions>true</extensions>
+						<configuration>
+							<serverId>ossrh</serverId>
+							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+							<autoReleaseAfterClose>true</autoReleaseAfterClose>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<version>2.2.1</version>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar-no-fork</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>2.9.1</version>
+						<executions>
+							<execution>
+								<id>attach-javadocs</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-gpg-plugin</artifactId>
+						<version>1.5</version>
+						<executions>
+							<execution>
+								<id>sign-artifacts</id>
+								<phase>verify</phase>
+								<goals>
+									<goal>sign</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 	<build>
 		<plugins>
@@ -105,17 +185,6 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.3</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>ossrh</serverId>
-					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-					<autoReleaseAfterClose>true</autoReleaseAfterClose>
-				</configuration>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 				<version>2.2.1</version>
@@ -137,20 +206,6 @@
 						<id>attach-javadocs</id>
 						<goals>
 							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-gpg-plugin</artifactId>
-				<version>1.5</version>
-				<executions>
-					<execution>
-						<id>sign-artifacts</id>
-						<phase>verify</phase>
-						<goals>
-							<goal>sign</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/src/main/java/pl/jsolve/sweetener/exception/InvalidArgumentException.java
+++ b/src/main/java/pl/jsolve/sweetener/exception/InvalidArgumentException.java
@@ -1,0 +1,11 @@
+package pl.jsolve.sweetener.exception;
+
+public class InvalidArgumentException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidArgumentException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/pl/jsolve/sweetener/exception/ResourceException.java
+++ b/src/main/java/pl/jsolve/sweetener/exception/ResourceException.java
@@ -1,0 +1,14 @@
+package pl.jsolve.sweetener.exception;
+
+public class ResourceException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ResourceException(String fileName, Exception ex) {
+        super(String.format("File: %s", fileName), ex);
+    }
+
+    public ResourceException(Exception ex) {
+        super(ex);
+    }
+}

--- a/src/main/java/pl/jsolve/sweetener/io/Resources.java
+++ b/src/main/java/pl/jsolve/sweetener/io/Resources.java
@@ -1,0 +1,17 @@
+package pl.jsolve.sweetener.io;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import pl.jsolve.sweetener.exception.ResourceException;
+
+public final class Resources {
+
+    public static void closeStream(Closeable closeable) {
+        try {
+            closeable.close();
+        } catch (IOException e) {
+            throw new ResourceException(e);
+        }
+    }
+}

--- a/src/main/java/pl/jsolve/sweetener/text/Escapes.java
+++ b/src/main/java/pl/jsolve/sweetener/text/Escapes.java
@@ -1,0 +1,173 @@
+package pl.jsolve.sweetener.text;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import pl.jsolve.sweetener.exception.InvalidArgumentException;
+
+public class Escapes {
+
+    private static final Map<Character, String> regexpSpecials = new HashMap<Character, String>();
+    private static final Map<Character, String> htmlSpecials = new HashMap<Character, String>();
+    private static final Map<Character, String> urlSpecials = new HashMap<Character, String>();
+    private static final Map<Character, String> xmlSpecials = new HashMap<Character, String>();
+    private static final Map<Character, String> jsonSpecials = new HashMap<Character, String>();
+
+    static {
+        regexpSpecial();
+        htmlSpecial();
+        urlSpecial();
+        xmlSpecial();
+        jsonSpecial();
+    }
+
+    private static void regexpSpecial() {
+        regexpSpecials.put('.', "\\.");
+        regexpSpecials.put('\\', "\\\\");
+        regexpSpecials.put('?', "\\?");
+        regexpSpecials.put('*', "\\*");
+        regexpSpecials.put('+', "\\+");
+        regexpSpecials.put('&', "\\&");
+        regexpSpecials.put(':', "\\:");
+        regexpSpecials.put('{', "\\{");
+        regexpSpecials.put('}', "\\}");
+        regexpSpecials.put('[', "\\[");
+        regexpSpecials.put(']', "\\]");
+        regexpSpecials.put('(', "\\(");
+        regexpSpecials.put(')', "\\)");
+        regexpSpecials.put('^', "\\^");
+        regexpSpecials.put('$', "\\$");
+    }
+
+    private static void htmlSpecial() {
+        htmlSpecials.put('<', "&lt;");
+        htmlSpecials.put('>', "&gt;");
+        htmlSpecials.put('&', "&amp;");
+        htmlSpecials.put('\"', "&quot;");
+        htmlSpecials.put('\t', "&#009;");
+        htmlSpecials.put('!', "&#033;");
+        htmlSpecials.put('#', "&#035;");
+        htmlSpecials.put('$', "&#036;");
+        htmlSpecials.put('%', "&#037;");
+        htmlSpecials.put('\'', "&#039;");
+        htmlSpecials.put('(', "&#040;");
+        htmlSpecials.put(')', "&#041;");
+        htmlSpecials.put('*', "&#042;");
+        htmlSpecials.put('+', "&#043;");
+        htmlSpecials.put(',', "&#044;");
+        htmlSpecials.put('-', "&#045;");
+        htmlSpecials.put('.', "&#046;");
+        htmlSpecials.put('/', "&#047;");
+        htmlSpecials.put(':', "&#058;");
+        htmlSpecials.put(';', "&#059;");
+        htmlSpecials.put('=', "&#061;");
+        htmlSpecials.put('?', "&#063;");
+        htmlSpecials.put('@', "&#064;");
+        htmlSpecials.put('[', "&#091;");
+        htmlSpecials.put('\\', "&#092;");
+        htmlSpecials.put(']', "&#093;");
+        htmlSpecials.put('^', "&#094;");
+        htmlSpecials.put('_', "&#095;");
+        htmlSpecials.put('`', "&#096;");
+        htmlSpecials.put('{', "&#123;");
+        htmlSpecials.put('|', "&#124;");
+        htmlSpecials.put('}', "&#125;");
+        htmlSpecials.put('~', "&#126;");
+    }
+
+    private static void urlSpecial() {
+        urlSpecials.put(' ', "%20");
+        urlSpecials.put('"', "%22");
+        urlSpecials.put('<', "%3c");
+        urlSpecials.put('>', "%3e");
+        urlSpecials.put('#', "%23");
+        urlSpecials.put('%', "%25");
+        urlSpecials.put('{', "%7b");
+        urlSpecials.put('}', "%7d");
+        urlSpecials.put('|', "%7c");
+        urlSpecials.put('\\', "%5c");
+        urlSpecials.put('^', "%5e");
+        urlSpecials.put('~', "%7e");
+        urlSpecials.put('[', "%5b");
+        urlSpecials.put(']', "%5d");
+        urlSpecials.put('`', "%60");
+    }
+
+    private static void xmlSpecial() {
+        xmlSpecials.put('<', "&lt;");
+        xmlSpecials.put('>', "&gt;");
+        xmlSpecials.put('\"', "&quot;");
+        xmlSpecials.put('\'', "&#039;");
+        xmlSpecials.put('&', "&amp;");
+    }
+
+    private static void jsonSpecial() {
+        jsonSpecials.put('\"', "\\\"");
+        jsonSpecials.put('\\', "\\\\");
+        jsonSpecials.put('/', "\\/");
+        jsonSpecials.put('\b', "\\b");
+        jsonSpecials.put('\f', "\\f");
+        jsonSpecials.put('\n', "\\n");
+        jsonSpecials.put('\r', "\\r");
+        jsonSpecials.put('\t', "\\t");
+    }
+
+    public static String escapeRegexp(String value) {
+        return escape(value, regexpSpecials);
+    }
+
+    public static String escapeHtml(String value) {
+        return escape(value, htmlSpecials);
+    }
+
+    public static String escapeUrl(String value) {
+        return escape(value, urlSpecials);
+    }
+
+    public static String escapeXml(String value) {
+        return escape(value, xmlSpecials);
+    }
+
+    public static String escapeJson(String value) {
+        return escape(value, jsonSpecials);
+    }
+
+    public static String escape(String value, Map<Character, String> specials) {
+        if (value == null) {
+            throw new InvalidArgumentException("String cannot be null");
+        }
+        if (specials == null) {
+            throw new InvalidArgumentException("Map cannot be null");
+        }
+        StringBuffer sb = new StringBuffer(value);
+        int countOfReplacements = 0;
+        for (int i = 0; i < value.length(); i++) {
+            if (specials.containsKey(value.charAt(i))) {
+                sb.deleteCharAt(i + countOfReplacements).insert(i + countOfReplacements, specials.get(value.charAt(i)));
+                countOfReplacements += specials.get(value.charAt(i)).length() - 1;
+            }
+        }
+        return sb.toString();
+    }
+
+    public static Map<Character, String> getRegexpspecials() {
+        return new HashMap<Character, String>(regexpSpecials);
+    }
+
+    public static Map<Character, String> getHtmlspecials() {
+        return new HashMap<Character, String>(htmlSpecials);
+    }
+
+    public static Map<Character, String> getUrlspecials() {
+        return new HashMap<Character, String>(urlSpecials);
+    }
+
+    public static Map<Character, String> getXmlspecials() {
+        return new HashMap<Character, String>(xmlSpecials);
+    }
+
+    public static Map<Character, String> getJsonspecials() {
+        return new HashMap<Character, String>(jsonSpecials);
+    }
+
+}

--- a/src/main/java/pl/jsolve/sweetener/text/Strings.java
+++ b/src/main/java/pl/jsolve/sweetener/text/Strings.java
@@ -1,0 +1,47 @@
+package pl.jsolve.sweetener.text;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Strings {
+
+    public static List<Integer> indexesOf(String sourceObject, String sequence, boolean ignoreRegexp) {
+        if (sequence == null) {
+            return new ArrayList<Integer>();
+        }
+        if (ignoreRegexp) {
+            return indexesOf(sourceObject, Escapes.escapeRegexp(sequence));
+        }
+        return indexesOf(sourceObject, sequence);
+    }
+
+    public static List<Integer> indexesOf(String sourceObject, String sequence) {
+        List<Integer> indexes = new ArrayList<Integer>();
+        if (sourceObject == null || sequence == null || sequence.isEmpty()) {
+            return indexes;
+        }
+        Pattern pattern = Pattern.compile(sequence);
+        Matcher matcher = pattern.matcher(sourceObject);
+        while (matcher.find()) {
+            indexes.add(matcher.start());
+        }
+        return indexes;
+    }
+
+    public static List<Integer> indexesOf(String sourceObject, Character c, boolean ignoreRegexp) {
+        if (c == null) {
+            return new ArrayList<Integer>();
+        }
+        if (ignoreRegexp) {
+            return indexesOf(sourceObject, Escapes.escapeRegexp(c.toString()));
+        }
+        return indexesOf(sourceObject, c.toString());
+    }
+
+    public static List<Integer> indexesOf(String sourceObject, Character c) {
+        return indexesOf(sourceObject, c, false);
+    }
+
+}

--- a/src/main/java/pl/jsolve/templ4docx/cleaner/ParagraphCleaner.java
+++ b/src/main/java/pl/jsolve/templ4docx/cleaner/ParagraphCleaner.java
@@ -1,8 +1,8 @@
 package pl.jsolve.templ4docx.cleaner;
 
+import java.util.ArrayList;
 import java.util.List;
 
-import pl.jsolve.sweetener.collection.Collections;
 import pl.jsolve.templ4docx.insert.ParagraphInsert;
 
 /**
@@ -14,7 +14,7 @@ public class ParagraphCleaner {
     private List<ParagraphInsert> paragraphs;
 
     public ParagraphCleaner() {
-        this.paragraphs = Collections.newArrayList();
+        this.paragraphs = new ArrayList<ParagraphInsert>();
     }
 
     /**

--- a/src/main/java/pl/jsolve/templ4docx/cleaner/TableRowCleaner.java
+++ b/src/main/java/pl/jsolve/templ4docx/cleaner/TableRowCleaner.java
@@ -1,10 +1,9 @@
 package pl.jsolve.templ4docx.cleaner;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.poi.xwpf.usermodel.XWPFTableRow;
-
-import pl.jsolve.sweetener.collection.Collections;
 
 /**
  * Container class which contains information about rows intended to remove.
@@ -15,7 +14,7 @@ public class TableRowCleaner {
     private List<XWPFTableRow> rows;
 
     public TableRowCleaner() {
-        this.rows = Collections.newArrayList();
+        this.rows = new ArrayList<XWPFTableRow>();
     }
 
     /**

--- a/src/main/java/pl/jsolve/templ4docx/extractor/KeyExtractor.java
+++ b/src/main/java/pl/jsolve/templ4docx/extractor/KeyExtractor.java
@@ -1,9 +1,9 @@
 package pl.jsolve.templ4docx.extractor;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 
-import pl.jsolve.sweetener.collection.Collections;
 import pl.jsolve.templ4docx.util.Key;
 import pl.jsolve.templ4docx.util.VariableType;
 import pl.jsolve.templ4docx.variable.BulletListVariable;
@@ -24,7 +24,7 @@ public class KeyExtractor {
      * @return list of keys for variables added to Variable object
      */
     public List<Key> extractKeys(Variables variables) {
-        List<Key> keys = Collections.newArrayList();
+        List<Key> keys = new ArrayList<Key>();
         for (Entry<String, TextVariable> entry : variables.getTextVariables().entrySet()) {
             keys.add(new Key(entry.getKey(), VariableType.TEXT));
         }

--- a/src/main/java/pl/jsolve/templ4docx/extractor/VariableFinder.java
+++ b/src/main/java/pl/jsolve/templ4docx/extractor/VariableFinder.java
@@ -1,5 +1,7 @@
 package pl.jsolve.templ4docx.extractor;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -11,8 +13,6 @@ import org.apache.poi.xwpf.usermodel.XWPFTable;
 import org.apache.poi.xwpf.usermodel.XWPFTableCell;
 import org.apache.poi.xwpf.usermodel.XWPFTableRow;
 
-import pl.jsolve.sweetener.collection.Collections;
-import pl.jsolve.sweetener.collection.Maps;
 import pl.jsolve.templ4docx.cleaner.ParagraphCleaner;
 import pl.jsolve.templ4docx.cleaner.TableRowCleaner;
 import pl.jsolve.templ4docx.insert.BulletListInsert;
@@ -51,7 +51,7 @@ public class VariableFinder {
      * @return List of inserts
      */
     public List<Insert> find(XWPFDocument document, Variables variables) {
-        List<Insert> inserts = Collections.newArrayList();
+        List<Insert> inserts = new ArrayList<Insert>();
         List<Key> keys = keyExtractor.extractKeys(variables);
         for (XWPFParagraph paragraph : document.getParagraphs()) {
             inserts.addAll(find(paragraph, document, null, keys));
@@ -93,7 +93,7 @@ public class VariableFinder {
      * @return
      */
     private List<Insert> find(XWPFParagraph paragraph, XWPFDocument document, XWPFTableCell cell, List<Key> keys) {
-        List<Insert> inserts = Collections.newArrayList();
+        List<Insert> inserts = new ArrayList<Insert>();
         StringBuilder sb = new StringBuilder();
         for (XWPFRun run : paragraph.getRuns()) {
             sb.append(run.getText(0));
@@ -130,8 +130,8 @@ public class VariableFinder {
      * @param variables Variables variables
      */
     private void mergeTableInserts(List<Insert> inserts, Variables variables) {
-        Map<XWPFTableRow, TableRowInsert> rowInserts = Maps.newHashMap();
-        List<Insert> insertsToRemove = Collections.newArrayList();
+        Map<XWPFTableRow, TableRowInsert> rowInserts = new HashMap<XWPFTableRow, TableRowInsert>();
+        List<Insert> insertsToRemove = new ArrayList<Insert>();
         for (Insert insert : inserts) {
             if (insert instanceof TableCellInsert) {
                 TableCellInsert cellInsert = (TableCellInsert) insert;

--- a/src/main/java/pl/jsolve/templ4docx/extractor/VariablesExtractor.java
+++ b/src/main/java/pl/jsolve/templ4docx/extractor/VariablesExtractor.java
@@ -7,7 +7,6 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 
-import pl.jsolve.sweetener.collection.Collections;
 import pl.jsolve.templ4docx.core.VariablePattern;
 
 /**
@@ -31,7 +30,7 @@ public class VariablesExtractor {
             tagValues.add(matcher.group());
         }
 
-        List<String> filteredValues = Collections.newArrayList();
+        List<String> filteredValues = new ArrayList<String>();
         for (String value : tagValues) {
             if (StringUtils.isNoneBlank(value) && StringUtils.startsWith(value, variablePattern.getOriginalPrefix())
                     && StringUtils.endsWith(value, variablePattern.getOriginalSuffix())) {

--- a/src/main/java/pl/jsolve/templ4docx/insert/TableRowInsert.java
+++ b/src/main/java/pl/jsolve/templ4docx/insert/TableRowInsert.java
@@ -1,10 +1,10 @@
 package pl.jsolve.templ4docx.insert;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.poi.xwpf.usermodel.XWPFTableRow;
 
-import pl.jsolve.sweetener.collection.Collections;
 import pl.jsolve.templ4docx.util.Key;
 import pl.jsolve.templ4docx.util.VariableType;
 
@@ -22,7 +22,7 @@ public class TableRowInsert extends Insert {
 
     public TableRowInsert() {
         super(new Key("", VariableType.TABLE));
-        this.cellInserts = Collections.newArrayList();
+        this.cellInserts = new ArrayList<TableCellInsert>();
     }
 
     public void add(TableCellInsert cellInsert) {

--- a/src/main/java/pl/jsolve/templ4docx/util/Key.java
+++ b/src/main/java/pl/jsolve/templ4docx/util/Key.java
@@ -1,8 +1,7 @@
 package pl.jsolve.templ4docx.util;
 
+import java.util.ArrayList;
 import java.util.List;
-
-import pl.jsolve.sweetener.collection.Collections;
 
 public class Key {
 
@@ -13,7 +12,7 @@ public class Key {
     public Key(String key, VariableType variableType) {
         this.key = key;
         this.variableType = variableType;
-        this.subKeys = Collections.newArrayList();
+        this.subKeys = new ArrayList<Key>();
     }
 
     public String getKey() {

--- a/src/main/java/pl/jsolve/templ4docx/variable/ImageVariable.java
+++ b/src/main/java/pl/jsolve/templ4docx/variable/ImageVariable.java
@@ -4,7 +4,8 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
+
+import org.apache.commons.io.FileUtils;
 
 public class ImageVariable implements Variable {
 
@@ -33,7 +34,7 @@ public class ImageVariable implements Variable {
             this.key = key;
             this.imageFile = imageFile;
             this.imagePath = imageFile.getAbsolutePath();
-            this.imageStream = new ByteArrayInputStream(Files.readAllBytes(imageFile.toPath()));
+            this.imageStream = new ByteArrayInputStream(FileUtils.readFileToByteArray(imageFile));
             this.width = width;
             this.height = height;
             this.imageType = imageType;

--- a/src/main/java/pl/jsolve/templ4docx/variable/TableOldVariable.java
+++ b/src/main/java/pl/jsolve/templ4docx/variable/TableOldVariable.java
@@ -1,12 +1,13 @@
 package pl.jsolve.templ4docx.variable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import pl.jsolve.sweetener.collection.Collections;
-import pl.jsolve.sweetener.collection.Maps;
 import pl.jsolve.templ4docx.exception.IncorrectNumberOfRowsException;
 import pl.jsolve.templ4docx.util.Key;
 import pl.jsolve.templ4docx.util.VariableType;
@@ -20,9 +21,9 @@ public class TableOldVariable implements Variable {
     private int numberOfRows = 0;
 
     public TableOldVariable() {
-        textVariables = Maps.newHashMap();
-        imageVariables = Maps.newHashMap();
-        bulletListVariables = Maps.newHashMap();
+        textVariables = new HashMap<String, List<TextVariable>>();
+        imageVariables = new HashMap<String, List<ImageVariable>>();
+        bulletListVariables = new HashMap<String, List<BulletListVariable>>();
     }
 
     public void addTextVariables(String key, List<String> textVariables) {
@@ -50,7 +51,7 @@ public class TableOldVariable implements Variable {
     }
 
     private List<TextVariable> convert(String key, List<String> values) {
-        List<TextVariable> textValues = Collections.newArrayList();
+        List<TextVariable> textValues = new ArrayList<TextVariable>();
         for (String value : values) {
             textValues.add(new TextVariable(key, value));
         }
@@ -118,7 +119,7 @@ public class TableOldVariable implements Variable {
     }
 
     public Set<Key> getKeys() {
-        Set<Key> keys = Collections.newHashSet();
+        Set<Key> keys = new HashSet<Key>();
         generateKeys(keys, textVariables.keySet(), VariableType.TEXT);
         generateKeys(keys, imageVariables.keySet(), VariableType.IMAGE);
         generateKeys(keys, bulletListVariables.keySet(), VariableType.BULLET_LIST);

--- a/src/main/java/pl/jsolve/templ4docx/variable/TableVariable.java
+++ b/src/main/java/pl/jsolve/templ4docx/variable/TableVariable.java
@@ -1,9 +1,10 @@
 package pl.jsolve.templ4docx.variable;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import pl.jsolve.sweetener.collection.Collections;
 import pl.jsolve.templ4docx.exception.IncorrectNumberOfRowsException;
 import pl.jsolve.templ4docx.util.Key;
 import pl.jsolve.templ4docx.util.VariableType;
@@ -14,7 +15,7 @@ public class TableVariable implements Variable {
     private int numberOfRows = 0;
 
     public TableVariable() {
-        this.variables = Collections.newArrayList();
+        this.variables = new ArrayList<List<? extends Variable>>();
     }
 
     public int getNumberOfRows() {
@@ -40,7 +41,7 @@ public class TableVariable implements Variable {
     }
 
     private Set<Key> extract(List<List<? extends Variable>> variables) {
-        Set<Key> keys = Collections.newHashSet();
+        Set<Key> keys = new HashSet<Key>();
 
         for (List<? extends Variable> variable : variables) {
             if (variable.isEmpty()) {

--- a/src/main/java/pl/jsolve/templ4docx/variable/Variables.java
+++ b/src/main/java/pl/jsolve/templ4docx/variable/Variables.java
@@ -1,10 +1,10 @@
 package pl.jsolve.templ4docx.variable;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import pl.jsolve.sweetener.collection.Collections;
-import pl.jsolve.sweetener.collection.Maps;
 import pl.jsolve.templ4docx.util.Key;
 
 public class Variables {
@@ -15,10 +15,10 @@ public class Variables {
     private Map<String, BulletListVariable> bulletListVariables;
 
     public Variables() {
-        this.textVariables = Maps.newHashMap();
-        this.imageVariables = Maps.newHashMap();
-        this.tableVariables = Collections.newArrayList();
-        this.bulletListVariables = Maps.newHashMap();
+        this.textVariables = new HashMap<String, TextVariable>();
+        this.imageVariables = new HashMap<String, ImageVariable>();
+        this.tableVariables = new ArrayList<TableVariable>();
+        this.bulletListVariables = new HashMap<String, BulletListVariable>();
     }
 
     public TextVariable addTextVariable(TextVariable textVariable) {


### PR DESCRIPTION
Some fixes for working with jdk6. It is impossible to build current version in `master` with jdk6 (https://github.com/jsolve/templ4docx/tree/master), but pom.xml contains `<java.version>1.6</java.version>`, so I made some changes in this PR. And it's seems it's difficult to port `sweetener` module to jdk6, so I drop this dependency and include necessary code from this module directly into this project. Ugly, but effective.